### PR TITLE
fix(builder): override default port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ src/**/*.js.map
 src/**/*.d.ts
 e2e/dist
 e2e-v6/dist
+packages/**/*.js
 
 # IDEs
 .idea/

--- a/packages/build-electron/src/start/index.ts
+++ b/packages/build-electron/src/start/index.ts
@@ -20,10 +20,10 @@ export class ElectronStartBuilder implements Builder<ElectronStartBuilderSchema>
     constructor(public context: BuilderContext) { }
 
     run(builderConfig: BuilderConfiguration<ElectronStartBuilderSchema>): Observable<BuildEvent> {
-        const targetString = builderConfig.options.browserTarget;
-        const [project, target, configuration] = targetString.split(':');
+        const { browserTarget, port } = builderConfig.options;
+        const [ project, target, configuration] = browserTarget.split(':');
         const devServerConfig = this.context.architect.getBuilderConfiguration(
-            { project, target, configuration }
+            { project, target, configuration, overrides: { port } }
         );
 
         const devServerObservable = of(null).pipe(

--- a/packages/build-electron/src/start/schema.d.ts
+++ b/packages/build-electron/src/start/schema.d.ts
@@ -1,6 +1,6 @@
-import { DevServerBuilderOptions } from '@angular-devkit/build-angular';
 import { WebpackBuilderSchema } from '@angular-devkit/build-webpack/src/webpack/schema';
 
-export interface ElectronStartBuilderSchema extends DevServerBuilderOptions, WebpackBuilderSchema {
-
+export interface ElectronStartBuilderSchema extends WebpackBuilderSchema {
+  browserTarget: string;
+  port: number;
 }

--- a/packages/schematics/src/ng-add/index.ts
+++ b/packages/schematics/src/ng-add/index.ts
@@ -78,6 +78,7 @@ function addAppToWorkspaceFile(options: ElectronOptions, workspace: WorkspaceSch
           options: {
             browserTarget: `${options.relatedAppName}:serve`,
             webpackConfig: `${projectRoot}webpack.config.js`,
+            port: 3000,
           },
           configurations: {
             dev: {


### PR DESCRIPTION
When running ng serve and ng serve electron simultaneously, there's a port collision.
So I simplified the ElectronStartBuilderSchema to have browserTarget, webpackConfig, and port.
Also, added build related files in the gitignore file.