### PR TITLE
feat(start): add inspect support

### DIFF
--- a/packages/build-electron/src/start/schema.d.ts
+++ b/packages/build-electron/src/start/schema.d.ts
@@ -2,5 +2,5 @@ import { DevServerBuilderOptions } from '@angular-devkit/build-angular';
 import { WebpackBuilderSchema } from '@angular-devkit/build-webpack/src/webpack/schema';
 
 export interface ElectronStartBuilderSchema extends DevServerBuilderOptions, WebpackBuilderSchema {
-
+  inspect: boolean;
 }

--- a/packages/build-electron/src/start/schema.json
+++ b/packages/build-electron/src/start/schema.json
@@ -133,9 +133,15 @@
     "webpackConfig": {
       "type": "string",
       "description": "The path to the Webpack configuration file."
+    },
+    "inspect": {
+      "type": "boolean",
+      "description": "Enable inspection of the main process.",
+      "default": false
     }
   },
   "additionalProperties": false,
   "required": [
     "webpackConfig"
-  ] }
+  ]
+}

--- a/packages/schematics/src/ng-add/index.ts
+++ b/packages/schematics/src/ng-add/index.ts
@@ -78,6 +78,7 @@ function addAppToWorkspaceFile(options: ElectronOptions, workspace: WorkspaceSch
           options: {
             browserTarget: `${options.relatedAppName}:serve`,
             webpackConfig: `${projectRoot}webpack.config.js`,
+            inspect: true
           },
           configurations: {
             dev: {


### PR DESCRIPTION
Sometimes after saving I get `Starting inspector on 127.0.0.1:9229 failed: address already in use`.
I guess that's related to that the previous electron window isn't closing fast enough.
I'll try to find a way to fix that.