### PR TITLE
feat(start): add electron params support

### DIFF
--- a/packages/build-electron/src/start/index.ts
+++ b/packages/build-electron/src/start/index.ts
@@ -21,7 +21,7 @@ export class ElectronStartBuilder implements Builder<ElectronStartBuilderSchema>
     constructor(public context: BuilderContext) { }
 
     run(builderConfig: BuilderConfiguration<ElectronStartBuilderSchema>): Observable<BuildEvent> {
-        const { browserTarget, webpackConfig, ...overrides } = builderConfig.options;
+        const { browserTarget, webpackConfig, electronParams, ...overrides } = builderConfig.options;
         const [project, target, configuration] = browserTarget.split(':');
         const devServerConfig = this.context.architect.getBuilderConfiguration(
             { project, target, configuration, overrides }
@@ -55,6 +55,12 @@ export class ElectronStartBuilder implements Builder<ElectronStartBuilderSchema>
         const dist = `${this.context.workspace.root}/dist/${project}`;
         const projectRoot = getSystemPath(normalize(dist));
 
+        const electronArgs = [projectRoot];
+        const { electronParams } = builderConfig.options;
+        if (electronParams) {
+            electronArgs.unshift(`${electronParams}`);
+        }
+
         const electron = require('electron');
 
         return new Observable((subscriber) => {
@@ -65,7 +71,7 @@ export class ElectronStartBuilder implements Builder<ElectronStartBuilderSchema>
                     ELECTRON_URL: this._serveAddress(builderConfig.options)
                 }
             };
-            const child = proc.spawn(electron, [projectRoot], options);
+            const child = proc.spawn(electron, electronArgs, options);
             child.on('close', () => subscriber.complete());
 
             const teardown: TeardownLogic = () => kill(child.pid, 'SIGKILL');

--- a/packages/build-electron/src/start/index.ts
+++ b/packages/build-electron/src/start/index.ts
@@ -58,7 +58,7 @@ export class ElectronStartBuilder implements Builder<ElectronStartBuilderSchema>
         const electronArgs = [projectRoot];
         const { electronParams } = builderConfig.options;
         if (electronParams) {
-            electronArgs.unshift(`${electronParams}`);
+          electronArgs.unshift(...electronParams.split(' '));
         }
 
         const electron = require('electron');

--- a/packages/build-electron/src/start/schema.d.ts
+++ b/packages/build-electron/src/start/schema.d.ts
@@ -2,5 +2,5 @@ import { DevServerBuilderOptions } from '@angular-devkit/build-angular';
 import { WebpackBuilderSchema } from '@angular-devkit/build-webpack/src/webpack/schema';
 
 export interface ElectronStartBuilderSchema extends DevServerBuilderOptions, WebpackBuilderSchema {
-
+    electronParams: string;
 }

--- a/packages/build-electron/src/start/schema.json
+++ b/packages/build-electron/src/start/schema.json
@@ -133,6 +133,11 @@
     "webpackConfig": {
       "type": "string",
       "description": "The path to the Webpack configuration file."
+    },
+
+    "electronParams": {
+      "type": "string",
+      "description": "A string of params to pass to the electron executable (eg. '--debug --inspect-brk=5858')."
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
Follow-up on my comment [here](https://github.com/ShPelles/electron-schematics/pull/22#issuecomment-455840431)

This PR adds support for "electronParams" serve option that will pass whatever string passed as a parameter to the electron executable, eg: ```--debug --inspect-brk=5858``` 

Note:
Maybe it will be a good idea to add ```"devtool: "source-map"``` to "packages/schematics/src/ng-add/files/webpack.config.js" and a default inspect value on "ng-add" - but I left it out for now.

See also: https://github.com/ShPelles/electron-schematics/pull/22
