### PR TITLE
Set baseHref to './'

### DIFF
--- a/packages/build-electron/src/build/index.ts
+++ b/packages/build-electron/src/build/index.ts
@@ -42,7 +42,7 @@ export class ElectronBuilder implements Builder<ElectronBuilderSchema> {
             { project, target, configuration }
         );
 
-        buildConfig.options.baseHref = '';
+        buildConfig.options.baseHref = './';
 
         return this.context.architect.run(buildConfig);
     }


### PR DESCRIPTION
Quick fix which allows the packaged app to resolve assets in the app.asar.
Without this the packaged app will not be able to resolve for example 'assets/hello.png' but will try to resolve 'index.html/assets/hello.png'